### PR TITLE
change SPV listener address to XagqqFetxiDb9wbartKDrXgnqLagy5yY1z

### DIFF
--- a/spv/spv_module.go
+++ b/spv/spv_module.go
@@ -32,8 +32,12 @@ func SpvInit() error {
 
 	spvService, err = spv.NewSPVService(config.Parameters.SpvMagic, config.Parameters.MainChainFoundationAddress, clientId,
 		config.Parameters.SpvSeedList, config.Parameters.SpvMinOutbound, config.Parameters.SpvMaxConnections)
+	if err != nil {
+		return err
+	}
+
 	//register an invalid address to prevent bloom filter from sending all data
-	spvService.RegisterTransactionListener(&SpvListener{ListenAddress: "0000000000000000000000000000000000"})
+	err = spvService.RegisterTransactionListener(&SpvListener{ListenAddress: "XagqqFetxiDb9wbartKDrXgnqLagy5yY1z"})
 	if err != nil {
 		return err
 	}

--- a/spv/spv_module_test.go
+++ b/spv/spv_module_test.go
@@ -1,0 +1,37 @@
+package spv
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/elastos/Elastos.ELA.Utility/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpvInit(t *testing.T) {
+	var programHash common.Uint168
+	programHash[0] = common.PrefixCrossChain
+	for i := 1; i < len(programHash); i++ {
+		programHash[i] = 0xff
+	}
+	fmt.Println(programHash[:])
+	address, err := programHash.ToAddress()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	fmt.Println(address)
+	fmt.Println(len(address))
+
+	hash, err := common.Uint168FromAddress(address)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	addr, err := hash.ToAddress()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	assert.Equal(t, address, addr)
+}


### PR DESCRIPTION
The "0000000000000000000000000000000000" is not an base58 format address, it can not be converted to an Uint168 program hash. Use XagqqFetxiDb9wbartKDrXgnqLagy5yY1z instead, witch is a program hash with 0xff in [1:21] bytes.