### PR TITLE
Fix some bugs

### DIFF
--- a/pow/pow.go
+++ b/pow/pow.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/elastos/Elastos.ELA.Utility/common"
 	"github.com/elastos/Elastos.ELA.Utility/crypto"
-	"github.com/elastos/Elastos.ELA.Utility/p2p/msg"
 	"github.com/elastos/Elastos.ELA.Utility/p2p/server"
 )
 
@@ -136,7 +135,6 @@ func (s *Service) DiscreteMining(n uint32) ([]*common.Uint256, error) {
 				if isOrphan || !inMainChain {
 					continue
 				}
-				s.BroadcastBlock(msgBlock)
 				h := msgBlock.Hash()
 				blockHashes[i] = &h
 				i++
@@ -218,7 +216,6 @@ func (s *Service) SubmitAuxBlock(blockHash string, sideAuxData []byte) error {
 	if isOrphan || !inMainChain {
 		return fmt.Errorf("aux block can not be accepted")
 	}
-	s.BroadcastBlock(msgBlock)
 
 	s.msgBlocks = make(map[string]*types.Block)
 
@@ -256,10 +253,6 @@ func (s *Service) SolveBlock(msgBlock *types.Block, ticker *time.Ticker) bool {
 	}
 
 	return false
-}
-
-func (s *Service) BroadcastBlock(block *types.Block) {
-	s.cfg.Server.BroadcastMessage(msg.NewBlock(block))
 }
 
 func (s *Service) Start() {
@@ -323,10 +316,8 @@ out:
 				if isOrphan || !inMainChain {
 					continue
 				}
-				s.BroadcastBlock(msgBlock)
 			}
 		}
-
 	}
 
 	s.wg.Done()

--- a/service/service.go
+++ b/service/service.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/elastos/Elastos.ELA.SideChain/blockchain"
 	"github.com/elastos/Elastos.ELA.SideChain/mempool"
 	"github.com/elastos/Elastos.ELA.SideChain/pow"
+	"github.com/elastos/Elastos.ELA.SideChain/server"
 	"github.com/elastos/Elastos.ELA.SideChain/types"
 
 	"github.com/elastos/Elastos.ELA.SideChain/spv"
@@ -17,12 +19,11 @@ import (
 	"github.com/elastos/Elastos.ELA.Utility/http/util"
 	"github.com/elastos/Elastos.ELA.Utility/p2p/msg"
 	"github.com/elastos/Elastos.ELA.Utility/p2p/peer"
-	"github.com/elastos/Elastos.ELA.Utility/p2p/server"
 	"github.com/elastos/Elastos.ELA/core"
 )
 
 type Config struct {
-	Server         server.IServer
+	Server         server.Server
 	Chain          *blockchain.BlockChain
 	Store          *blockchain.ChainStore
 	GenesisAddress string
@@ -889,7 +890,9 @@ func (s *HttpService) verifyAndSendTx(tx *types.Transaction) error {
 		}
 		return err
 	}
-	s.cfg.Server.BroadcastMessage(msg.NewTx(tx))
+	hash := tx.Hash()
+	iv := msg.NewInvVect(msg.InvTypeTx, &hash)
+	s.cfg.Server.RelayInventory(iv, tx)
 	return nil
 }
 


### PR DESCRIPTION
1. The block broadcast was duplicate, blocks will be relayed when added to MainChain, so no need to broadcast.
2. Use RelayInventory instead of BroadcastMassage for transactions from RPC interface.