### PR TITLE
Make SPV transaction filter configurable

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -29,6 +29,25 @@ const (
 	MaxBlocksPerMsg = 500
 )
 
+// Config defines the parameters to create a server instance.
+type Config struct {
+	// DataDir indicates the path the store data files.
+	DataDir string
+
+	// Chain represents the BlockChain instance.
+	Chain *blockchain.BlockChain
+
+	// TxMemPool represents the TxPool instance.
+	TxMemPool *mempool.TxPool
+
+	// ChainParams represents the active net parameters.
+	ChainParams *config.Params
+
+	// NewTxFilter indicates the function to create a TxFilter according to the
+	// TxFilterType.
+	NewTxFilter func(filter.TxFilterType) filter.TxFilter
+}
+
 // naFilter defines a network address filter for the side chain server, for now
 // it is used to filter SPV wallet addresses from relaying to other peers.
 type naFilter struct{}
@@ -64,6 +83,7 @@ type server struct {
 	syncManager *netsync.SyncManager
 	chain       *blockchain.BlockChain
 	txMemPool   *mempool.TxPool
+	newTxFiler  func(filter.TxFilterType) filter.TxFilter
 
 	peerQueue chan interface{}
 	relayInv  chan relayMsg
@@ -89,19 +109,9 @@ type serverPeer struct {
 // newServerPeer returns a new serverPeer instance. The peer needs to be set by
 // the caller.
 func newServerPeer(s *server) *serverPeer {
-	filter := filter.New(func(filterType filter.TxFilterType) filter.TxFilter {
-		switch filterType {
-		case filter.FTBloom:
-			return bloom.NewTxFilter()
-		case filter.FTTxType:
-			return filter.NewTxTypeFilter()
-		}
-		return nil
-	})
-
 	return &serverPeer{
 		server:         s,
-		filter:         filter,
+		filter:         filter.New(s.newTxFiler),
 		quit:           make(chan struct{}),
 		txProcessed:    make(chan struct{}, 1),
 		blockProcessed: make(chan struct{}, 1),
@@ -781,10 +791,10 @@ func (s *server) Stop() error {
 	return nil
 }
 
-// newServer returns a new btcd server configured to listen on addr for the
-// network type specified by chainParams.  Use start to begin accepting
-// connections from peers.
-func New(dataDir string, chain *blockchain.BlockChain, txPool *mempool.TxPool, params *config.Params) (*server, error) {
+// New returns a new server instance configured to specified config parameters.
+// Use start to begin accepting connections from peers.
+func New(cfg *Config) (*server, error) {
+	params := cfg.ChainParams
 	services := defaultServices
 	if params.DisableTxFilters {
 		services &^= pact.SFNodeBloom
@@ -795,7 +805,20 @@ func New(dataDir string, chain *blockchain.BlockChain, txPool *mempool.TxPool, p
 		params.ListenAddrs = []string{fmt.Sprint(":", params.DefaultPort)}
 	}
 
-	cfg := p2psvr.NewDefaultConfig(
+	// If NewTxFilter not set, create a default one.
+	if cfg.NewTxFilter == nil {
+		cfg.NewTxFilter = func(filterType filter.TxFilterType) filter.TxFilter {
+			switch filterType {
+			case filter.FTBloom:
+				return bloom.NewTxFilter()
+			case filter.FTTxType:
+				return filter.NewTxTypeFilter()
+			}
+			return nil
+		}
+	}
+
+	svrcfg := p2psvr.NewDefaultConfig(
 		params.Magic,
 		pact.EBIP002Version,
 		uint64(services),
@@ -803,23 +826,24 @@ func New(dataDir string, chain *blockchain.BlockChain, txPool *mempool.TxPool, p
 		params.SeedList,
 		params.ListenAddrs,
 		nil, nil, makeEmptyMessage,
-		func() uint64 { return uint64(chain.GetBestHeight()) },
+		func() uint64 { return uint64(cfg.Chain.GetBestHeight()) },
 	)
-	cfg.DataDir = dataDir
-	cfg.NAFilter = &naFilter{}
+	svrcfg.DataDir = cfg.DataDir
+	svrcfg.NAFilter = &naFilter{}
 
 	s := server{
-		chain:     chain,
-		txMemPool: txPool,
-		peerQueue: make(chan interface{}, cfg.MaxPeers),
-		relayInv:  make(chan relayMsg, cfg.MaxPeers),
-		quit:      make(chan struct{}),
-		services:  services,
+		chain:      cfg.Chain,
+		txMemPool:  cfg.TxMemPool,
+		newTxFiler: cfg.NewTxFilter,
+		peerQueue:  make(chan interface{}, svrcfg.MaxPeers),
+		relayInv:   make(chan relayMsg, svrcfg.MaxPeers),
+		quit:       make(chan struct{}),
+		services:   services,
 	}
-	cfg.OnNewPeer = s.NewPeer
-	cfg.OnDonePeer = s.DonePeer
+	svrcfg.OnNewPeer = s.NewPeer
+	svrcfg.OnDonePeer = s.DonePeer
 
-	p2pServer, err := p2psvr.NewServer(cfg)
+	p2pServer, err := p2psvr.NewServer(svrcfg)
 	if err != nil {
 		return nil, err
 	}
@@ -829,7 +853,7 @@ func New(dataDir string, chain *blockchain.BlockChain, txPool *mempool.TxPool, p
 		PeerNotifier: &s,
 		Chain:        s.chain,
 		TxMemPool:    s.txMemPool,
-		MaxPeers:     cfg.MaxPeers,
+		MaxPeers:     svrcfg.MaxPeers,
 	})
 
 	return &s, nil


### PR DESCRIPTION
This change is to make the TxFilter for SPV clients configurable. 
For example the Token chain needs all RegisterToken transactions send to the SPV client, we need a different TxFilter other than the default TxFilter.